### PR TITLE
Support module.exports in the browser

### DIFF
--- a/arc.js
+++ b/arc.js
@@ -246,7 +246,7 @@ GreatCircle.prototype.Arc = function(npoints,options) {
     return arc;
 };
 
-if (typeof window === 'undefined') {
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   // nodejs
   module.exports.Coord = Coord;
   module.exports.Arc = Arc;


### PR DESCRIPTION
This fixed an issue I was having with importing arc.js into a webpack-bundled application. 