### PR TITLE
Fix error with antipodal error generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.1.3
+
+- Fix bug when generating string for Antipodal error
 
 # v0.1.2
 

--- a/arc.js
+++ b/arc.js
@@ -96,7 +96,7 @@ var GreatCircle = function(start,end,properties) {
     this.g = 2.0 * Math.asin(Math.sqrt(z));
 
     if (this.g == Math.PI) {
-        throw new Error('it appears ' + start.view() + ' and ' + end.view() + " are 'antipodal', e.g diametrically opposite, thus there is no single route but rather infinite");
+        throw new Error('it appears ' + this.start.view() + ' and ' + this.end.view() + " are 'antipodal', e.g diametrically opposite, thus there is no single route but rather infinite");
     } else if (isNaN(this.g)) {
         throw new Error('could not calculate great circle between ' + start + ' and ' + end);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "draw great circle arcs",
   "url": "https://github.com/springmeyer/arc.js",
   "keywords": [

--- a/test/arc.test.js
+++ b/test/arc.test.js
@@ -37,6 +37,21 @@ test('GreatCircle', function(t) {
     t.end();
 });
 
+test('GreatCircleException', function(t) {
+    try {
+        new arc.GreatCircle({
+            x: 1, y: 1
+        }, {
+            x: -179, y: -1
+        });
+    }
+    catch (e) {
+        t.equal(e.toString(), "Error: it appears 1,1 and -179,-1 are 'antipodal', e.g diametrically opposite, thus " +
+            "there is no single route but rather infinite" , "Antipodal error test");
+    }
+    t.end();
+});
+
 var routes = [
     [{x: -122, y: 48}, {x: -77, y:  39}, {'name': 'Seattle to DC'}],
     [{x: -122, y: 48}, {x: 0, y:  51}, {'name': 'Seattle to London'}],


### PR DESCRIPTION
The "start" and "end" variables referenced in the error message were not of type Coord, and the code would crash since the .view() function didn't exist. This PR makes changes to reference the correct variables. 