### PR TITLE
chore: use importmap/esm.sh in demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,8 +351,15 @@
             </div>
         </div>
     </div>
+    <script type="importmap">
+        {
+            "imports": {
+                "arc": "https://esm.sh/arc@1"
+            }
+        }
+    </script>
     <script type="module">
-        import { GreatCircle } from 'https://cdn.skypack.dev/arc@1';
+        import { GreatCircle } from "arc";
         
         // Initialize map
         var map = L.map('map').setView(new L.LatLng(0, 0), 2);


### PR DESCRIPTION
i'm not sure why, but https://cdn.skypack.dev/arc@1 still doesn't resolve.

all these work 🤷 
https://cdn.skypack.dev/arc
https://cdn.skypack.dev/arc@1.0.0
https://cdn.skypack.dev/arc@latest

this PR swaps in esm.sh and importmap syntax instead.

ref: https://github.com/skypackjs/skypack-cdn/issues/365