### PR TITLE
Use valid SPDX license id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arc",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arc",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "BSD",
       "devDependencies": {
         "@types/geojson": "^7946.0.16",
@@ -18,7 +18,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "arc",
       "version": "1.0.0",
-      "license": "BSD",
+      "license": "BSD-2-Clause",
       "devDependencies": {
         "@types/geojson": "^7946.0.16",
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "git://github.com/springmeyer/arc.js.git"
   },
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "type": "module",
   "exports": {
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
`BSD` is not a recognised SPDX license id. Looking at `LICENSE` and I think it should be “BSD-2-Clause”: https://spdx.org/licenses/BSD-2-Clause.html

Also, seems like `npm install` was not ran after bumping version from 0.2.0 to 1.0.0, as `package-lock.json` did not match.